### PR TITLE
Ошибка получения цены в offers.xml

### DIFF
--- a/upload/admin/model/extension/exchange1c.php
+++ b/upload/admin/model/extension/exchange1c.php
@@ -5113,7 +5113,7 @@ class ModelExtensionExchange1c extends Model {
 			foreach ($xml->Цена as $price_data) {
 
 				$guid	= (string)$price_data->ИдТипаЦены;
-				$price	= $price_data->ЦенаЗаЕдиницу ? (float)$price_data->ЦенаЗаЕдиницу : 0;
+				$price	= $price_data->ЦенаЗаЕдиницу ? (float)str_replace(',', '.', $price_data->ЦенаЗаЕдиницу) : 0;
 
 				if ($config_price_type['guid'] != $guid) {
 					continue;


### PR DESCRIPTION
PHP по правилам приведения _string_ во _float_ не распознаёт в последовательности `9,6` дробную часть после запятой. Корректный вариант выглядит как `9.6`, поэтому необходимо заменять запятые на точки функцией `str_replace`.