### PR TITLE
remove OpenBay Pro reference

### DIFF
--- a/upload/export/exchange1c.php
+++ b/upload/export/exchange1c.php
@@ -186,9 +186,6 @@ $registry->set('length', new Cart\Length($registry));
 // User
 $registry->set('user', new Cart\User($registry));
 
-//OpenBay Pro
-$registry->set('openbay', new Openbay($registry));
-
 // Event
 $event = new Event($registry);
 $registry->set('event', $event);


### PR DESCRIPTION
Удалена ссылка на OpenBay Pro -- в ocStore и OpenCart "Русская сборка" этот модуль удален, что вызывает ошибку.